### PR TITLE
Feature - add code blocks functionality

### DIFF
--- a/codeBlocks.txt
+++ b/codeBlocks.txt
@@ -1,0 +1,5 @@
+```javascript
+function helloWord(){
+    console.log("helloWord");
+}
+```

--- a/examples/codeBlocks.txt
+++ b/examples/codeBlocks.txt
@@ -1,0 +1,5 @@
+```javascript
+function helloWord(){
+    console.log("helloWord");
+}
+```

--- a/src/utility/helper.ts
+++ b/src/utility/helper.ts
@@ -86,3 +86,25 @@ export function writeMultipleFiles(
     }
   }
 }
+
+export function unwrapCodeBlocks(content: string): string {
+  // We only support 3/4 backticks on purpose, should be good enough
+  // const regexp3 = /(?<begin>^|\n)```jsx\n(?<children>.*?)\n```(?<end>\n|$)/g;
+  const regex = /```(.*?)\n(.*?)\n```/gs;
+  content.replace(regex, function (match, lang, code) {
+    if (lang === "") {
+      content = `<pre><code>
+      ${code}
+   </code></pre>`;
+    } else {
+      content =
+        `<pre><code class="language-${lang}">` +
+        `
+      ${code}
+      </code></pre>`;
+    }
+
+    return content;
+  });
+  return content;
+}

--- a/src/utility/htmlCreator.ts
+++ b/src/utility/htmlCreator.ts
@@ -15,6 +15,11 @@ export function htmlCreator(
       <head>
       <meta charset="utf-8">
       <title>${title}</title>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/0.0.1/prism.min.js"></script>
+      <link
+        href="https://cdnjs.cloudflare.com/ajax/libs/prism/0.0.1/prism.min.css"
+        rel="stylesheet"
+      />
       <meta name="viewport" content="width=device-width, initial-scale=1">
       ${
         stylesheetURL === ""

--- a/src/utility/readFile.ts
+++ b/src/utility/readFile.ts
@@ -1,9 +1,10 @@
 import path from "path";
 import fs from "fs";
-
+import { unwrapCodeBlocks } from "./helper";
 export function readFile(filename: string) {
   try {
-    const contents = fs.readFileSync(path.join(__dirname, filename), "utf-8");
+    let contents = fs.readFileSync(path.join(__dirname, filename), "utf-8");
+    contents = unwrapCodeBlocks(contents);
     const arr = contents.split(/\r?\n/);
     return arr;
   } catch (err) {


### PR DESCRIPTION
Fix #12 
`Til-tool` can read `code blocks` in `.md` file and convert it into `.html` file with `prism`